### PR TITLE
Fix: if webconsole not launched, terminate CGF

### DIFF
--- a/internal/cgf/cgf.go
+++ b/internal/cgf/cgf.go
@@ -156,12 +156,13 @@ func (f *Cgf) Serve(wg *sync.WaitGroup) {
 		wg.Done()
 	}()
 
-	for i := 0; i < FTP_LOGIN_RETRY_NUMBER; i++ {
+	for i := 0; ; i++ {
 		if err := Login(); err != nil {
 			if i < FTP_LOGIN_RETRY_NUMBER {
 				logger.CgfLog.Warnf("Login to Webconsole FTP fail: %s, retrying [%d]\n", err, i+1)
 			} else {
 				logger.CgfLog.Errorln("Login to Webconsole FTP fail ", err)
+				return
 			}
 			time.Sleep(FTP_LOGIN_RETRY_WAITING_TIME)
 		} else {


### PR DESCRIPTION
This PR fix the issue: https://github.com/free5gc/free5gc/issues/488.
If webconsole isn't launched, free5gc/chf will stuck at CGF FTP starting, and stuck the core network.