### PR TITLE
CHF Should not SendCDR() to BD when received Charging Data Request 

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -49,6 +49,7 @@ func (context *CHFContext) AddChfUeToUePool(ue *ChfUe, supi string) {
 
 // Allocate CHF Ue with supi and add to chf Context and returns allocated ue
 func (context *CHFContext) NewCHFUe(supi string) (*ChfUe, error) {
+	logger.ChargingdataPostLog.Infof("NewCHFUe: %s", supi)
 	if ue, ok := context.ChfUeFindBySupi(supi); ok {
 		return ue, nil
 	}

--- a/internal/sbi/producer/cdr.go
+++ b/internal/sbi/producer/cdr.go
@@ -52,7 +52,7 @@ func OpenCDR(chargingData models.ChargingDataRequest, ue *chf_context.ChfUe, ses
 	}
 
 	// 32.298 5.1.5.1.5 Local Record Sequence Number
-	// TODO determine local record sequnece number
+	// TODO determine Local Record Sequenece Number
 	self.LocalRecordSequenceNumber++
 	chfCdr.LocalRecordSequenceNumber = &cdrType.LocalSequenceNumber{
 		Value: int64(self.LocalRecordSequenceNumber),
@@ -242,6 +242,7 @@ func CloseCDR(record *cdrType.CHFRecord, partial bool) error {
 }
 
 func dumpCdrFile(ueid string, records []*cdrType.CHFRecord) error {
+	logger.ChargingdataPostLog.Infof("dump CDR File")
 	var cdrfile cdrFile.CDRFile
 	cdrfile.Hdr.LengthOfCdrRouteingFilter = 0
 	cdrfile.Hdr.LengthOfPrivateExtension = 0

--- a/internal/sbi/producer/converged_charging.go
+++ b/internal/sbi/producer/converged_charging.go
@@ -192,7 +192,6 @@ func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.Chargi
 	logger.ChargingdataPostLog.Infof("Open CDR for UE %s", ueId)
 
 	// build response
-	logger.ChargingdataPostLog.Infof("NewChfUe %s", ueId)
 	locationURI := self.Url + "/nchf-convergedcharging/v3/chargingdata/" + chargingSessionId
 	timeStamp := time.Now()
 

--- a/internal/sbi/producer/converged_charging.go
+++ b/internal/sbi/producer/converged_charging.go
@@ -132,6 +132,7 @@ func HandleChargingdataRelease(request *httpwrapper.Request) *httpwrapper.Respon
 
 func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.ChargingDataResponse,
 	string, *models.ProblemDetails) {
+	logger.ChargingdataPostLog.Infoln("Create Charging Data")
 	var responseBody models.ChargingDataResponse
 	var chargingSessionId string
 
@@ -140,7 +141,7 @@ func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.Chargi
 
 	// Open CDR
 	// ChargingDataRef(charging session id):
-	// A unique identifier for a charging data resource in a PLMN
+	// An unique identifier for a charging data resource in a PLMN
 	// TODO determine charging session id(string type) supi+consumerid+localseq?
 	ue, err := self.NewCHFUe(ueId)
 	if err != nil {
@@ -188,12 +189,6 @@ func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.Chargi
 		}
 	}
 
-	// CDR Transfer
-	err = cgf.SendCDR(chargingData.SubscriberIdentifier)
-	if err != nil {
-		logger.ChargingdataPostLog.Errorf("Charging gateway fail to send CDR to billing domain %v", err)
-	}
-
 	logger.ChargingdataPostLog.Infof("Open CDR for UE %s", ueId)
 
 	// build response
@@ -209,6 +204,7 @@ func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.Chargi
 
 func ChargingDataUpdate(chargingData models.ChargingDataRequest, chargingSessionId string) (*models.ChargingDataResponse,
 	*models.ProblemDetails) {
+	logger.ChargingdataPostLog.Infoln("Update Charging Data")
 	var records []*cdrType.CHFRecord
 
 	self := chf_context.GetSelf()
@@ -266,7 +262,7 @@ func ChargingDataUpdate(chargingData models.ChargingDataRequest, chargingSession
 
 	err = cgf.SendCDR(chargingData.SubscriberIdentifier)
 	if err != nil {
-		logger.ChargingdataPostLog.Errorf("Charging gateway fail to send CDR to billing domain %v", err)
+		logger.ChargingdataPostLog.Errorf("Charging gateway fail to send CDR to billing domain: %v", err)
 	}
 
 	timeStamp := time.Now()

--- a/internal/sbi/producer/converged_charging.go
+++ b/internal/sbi/producer/converged_charging.go
@@ -157,9 +157,9 @@ func ChargingDataCreate(chargingData models.ChargingDataRequest) (*models.Chargi
 
 	ue.NotifyUri = chargingData.NotifyUri
 
-	consumerId := chargingData.NfConsumerIdentification.NFName
+	consumerNfName := chargingData.NfConsumerIdentification.NFName
 	if !chargingData.OneTimeEvent {
-		chargingSessionId = ueId + consumerId + strconv.Itoa(int(self.LocalRecordSequenceNumber))
+		chargingSessionId = ueId + consumerNfName + strconv.Itoa(int(self.LocalRecordSequenceNumber))
 	}
 	cdr, err := OpenCDR(chargingData, ue, chargingSessionId, false)
 	if err != nil {


### PR DESCRIPTION
This PR fix the error:
![image](https://github.com/free5gc/chf/assets/46628572/43006370-32ee-48ad-8336-42a9fac6c06b)
CHF should not send CDR to BD immediately when CDR is just opened. Because no CDR file in `/tmp/[supi].cdr` is created.

CDR file should be closed and send to BD when one of the below condition matches (_TS 32.297 5.1.3_):
![image](https://github.com/free5gc/chf/assets/46628572/713618ff-bdae-4770-a965-a9b99e8e75b6)

This error message happend in step 9a-c
![image](https://github.com/free5gc/chf/assets/46628572/19641855-d8e6-44c8-b574-5bfe9b862027)

CDR File format (_TS 32.297 Figure 5.2.1_):
![image](https://github.com/free5gc/chf/assets/46628572/590cde72-e604-477b-b90f-a4faed116d56)



