### PR TITLE
Run go staticcheck & removing reported warnings

### DIFF
--- a/cdr/asn/ber_marshal.go
+++ b/cdr/asn/ber_marshal.go
@@ -170,7 +170,7 @@ func (b bitStringEncoder) Encode(dst []byte) {
 }
 
 // NOTE: for managementextension field
-type oidEncoder ObjectIdentifier
+// type oidEncoder ObjectIdentifier		// Commenting as unused
 
 func makeField(v reflect.Value, params fieldParameters) (encoder, error) {
 	if !v.IsValid() {
@@ -219,7 +219,7 @@ func makeField(v reflect.Value, params fieldParameters) (encoder, error) {
 			tag.class = ClassUniversal
 			tag.constructed = false
 			tag.tagNumber = TagBoolean
-			if v.Bool() == true {
+			if v.Bool() {
 				berType.value = byteEncoder(0xff)
 			} else {
 				berType.value = byteEncoder(0)
@@ -295,7 +295,7 @@ func makeField(v reflect.Value, params fieldParameters) (encoder, error) {
 					var err error
 					s[i], err = makeField(val.Field(i), tempParams)
 					if err != nil {
-						fmt.Errorf("iterate subtype error")
+						return nil, fmt.Errorf("iterate subtype error")
 					}
 
 					berType.value = structEncoder(s)
@@ -316,7 +316,7 @@ func makeField(v reflect.Value, params fieldParameters) (encoder, error) {
 			for i := 0; i < v.Len(); i++ {
 				s[i], err = makeField(val.Index(i), tempParams)
 				if err != nil {
-					fmt.Errorf("iterate subtype error")
+					return nil, fmt.Errorf("iterate subtype error")
 				}
 			}
 

--- a/cdr/asn/ber_unmarshal.go
+++ b/cdr/asn/ber_unmarshal.go
@@ -40,6 +40,7 @@ func parseTagAndLength(bytes []byte) (r tagAndLen, off int, e error) {
 		// fmt.Println("len", len)
 		if len > 3 {
 			e = fmt.Errorf("length is too large")
+			return
 		}
 		off++
 		var val int64

--- a/pkg/abmf/abmf.go
+++ b/pkg/abmf/abmf.go
@@ -92,16 +92,17 @@ func printErrors(ec <-chan *diam.ErrorReport) {
 	}
 }
 
-func listen(addr, cert, key string, handler diam.Handler) error {
-	// Start listening for connections.
-	if len(cert) > 0 && len(key) > 0 {
-		logger.AcctLog.Infof("Starting secure diameter server on %s", addr)
-		return diam.ListenAndServeTLS(addr, cert, key, handler, nil)
-	}
+// Commenting the unused function
+// func listen(addr, cert, key string, handler diam.Handler) error {
+// 	// Start listening for connections.
+// 	if len(cert) > 0 && len(key) > 0 {
+// 		logger.AcctLog.Infof("Starting secure diameter server on %s", addr)
+// 		return diam.ListenAndServeTLS(addr, cert, key, handler, nil)
+// 	}
 
-	logger.AcctLog.Infof("Starting diameter server on %s", addr)
-	return diam.ListenAndServe(addr, handler, nil)
-}
+// 	logger.AcctLog.Infof("Starting diameter server on %s", addr)
+// 	return diam.ListenAndServe(addr, handler, nil)
+// }
 
 func handleCCR() diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {

--- a/pkg/factory/config.go
+++ b/pkg/factory/config.go
@@ -147,15 +147,16 @@ type Mongodb struct {
 	Url  string `yaml:"url" valid:"required"`
 }
 
-func (m *Mongodb) validate() (bool, error) {
-	pattern := `[-a-zA-Z0-9@:%._\+~#=]{1,256}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
-	if result := govalidator.StringMatches(m.Url, pattern); !result {
-		err := fmt.Errorf("Invalid Url: %s", m.Url)
-		return result, err
-	}
-	result, err := govalidator.ValidateStruct(m)
-	return result, err
-}
+// Commenting the unused function
+// func (m *Mongodb) validate() (bool, error) {
+// 	pattern := `[-a-zA-Z0-9@:%._\+~#=]{1,256}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
+// 	if result := govalidator.StringMatches(m.Url, pattern); !result {
+// 		err := fmt.Errorf("Invalid Url: %s", m.Url)
+// 		return result, err
+// 	}
+// 	result, err := govalidator.ValidateStruct(m)
+// 	return result, err
+// }
 
 func appendInvalid(err error) error {
 	var errs govalidator.Errors

--- a/pkg/rf/rating.go
+++ b/pkg/rf/rating.go
@@ -91,16 +91,17 @@ func printErrors(ec <-chan *diam.ErrorReport) {
 	}
 }
 
-func listen(addr, cert, key string, handler diam.Handler) error {
-	// Start listening for connections.
-	if len(cert) > 0 && len(key) > 0 {
-		logger.RatingLog.Infof("Starting secure diameter server on %s", addr)
-		return diam.ListenAndServeTLS(addr, cert, key, handler, nil)
-	}
+// Commenting the unused function
+// func listen(addr, cert, key string, handler diam.Handler) error {
+// 	// Start listening for connections.
+// 	if len(cert) > 0 && len(key) > 0 {
+// 		logger.RatingLog.Infof("Starting secure diameter server on %s", addr)
+// 		return diam.ListenAndServeTLS(addr, cert, key, handler, nil)
+// 	}
 
-	logger.RatingLog.Infof("Starting diameter server on %s", addr)
-	return diam.ListenAndServe(addr, handler, nil)
-}
+// 	logger.RatingLog.Infof("Starting diameter server on %s", addr)
+// 	return diam.ListenAndServe(addr, handler, nil)
+// }
 
 func buildTaffif(unitCostStr string) *charging_datatype.MonetaryTariff {
 	// unitCost


### PR DESCRIPTION
Running go [staticcheck](https://staticcheck.io/docs/) & removed reported warnings.
Used below `staticcheck.conf` file as the staticcheck configuration file:
```
checks = ["all", "-ST1005", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
initialisms = ["ACL", "API", "ASCII", "CPU", "CSS", "DNS", "EOF", "GUID", "HTML", "HTTP", "HTTPS", "ID", "IP", "JSON", "QPS", "RAM", "RPC", "SLA", "SMTP", "SQL", "SSH", "TCP", "TLS", "TTL", "UDP", "UI", "GID", "UID", "UUID", "URI", "URL", "UTF8", "VM", "XML", "XMPP", "XSRF", "XSS", "SIP", "RTP", "AMQP", "DB", "TS"]
dot_import_whitelist = ["github.com/mmcloughlin/avo/build", "github.com/mmcloughlin/avo/operand", "github.com/mmcloughlin/avo/reg", "github.com/free5gc/openapi/models"]
http_status_code_whitelist = ["200", "400", "404", "500"]

```

Warnings reported by staticcheck:

> cdr/asn/ber_marshal.go:173:6: type oidEncoder is unused (U1000)
> cdr/asn/ber_marshal.go:222:7: should omit comparison to bool constant, can be simplified to v.Bool() (S1002)
> cdr/asn/ber_marshal.go:298:7: Errorf doesn't have side effects and its return value is ignored (SA4017)
> cdr/asn/ber_marshal.go:319:6: Errorf doesn't have side effects and its return value is ignored (SA4017)
> cdr/asn/ber_unmarshal.go:42:4: this value of e is never used (SA4006)
> cdr/asn/ber_unmarshal.go:42:8: Errorf doesn't have side effects and its return value is ignored (SA4017)
> pkg/abmf/abmf.go:95:6: func listen is unused (U1000)
> pkg/factory/config.go:150:19: func (*Mongodb).validate is unused (U1000)
> pkg/rf/rating.go:94:6: func listen is unused (U1000)