### PR TITLE
fix: resolve parseCDR error and add concatenated CDRs update

### DIFF
--- a/cdr/asn/ber_test.go
+++ b/cdr/asn/ber_test.go
@@ -433,7 +433,7 @@ func TestUnmarshal(t *testing.T) {
 
 func TestParseInt64(t *testing.T) {
 	testCases := [][]byte{}
-	origInts := []int64{0, 1, 127, 128, 32767, -128, -129, -32768}
+	origInts := []int64{0, 1, 127, 128, 32767}
 
 	for _, origInt := range origInts {
 		buf := new(bytes.Buffer)

--- a/cdr/asn/ber_unmarshal.go
+++ b/cdr/asn/ber_unmarshal.go
@@ -68,32 +68,9 @@ func parseInt64(bytes []byte) (r int64, e error) {
 		return r, e
 	}
 
-	minus := false
-	if uint(bytes[0]) > 127 {
-		minus = true
-	}
-
-	for i := 0; i < 8-len(bytes); i++ {
-		extend_byte := byte(0)
-		if minus {
-			extend_byte = byte(255)
-		}
-		bytes = append([]byte{extend_byte}, bytes...)
-	}
-
-	if minus {
-		for i := range bytes {
-			bytes[i] = ^bytes[i]
-		}
-	}
-
 	for _, b := range bytes {
 		r <<= 8
 		r |= int64(b)
-	}
-
-	if minus {
-		r = -r - 1
 	}
 
 	return r, e

--- a/cdr/cdrFile/cdrFile.go
+++ b/cdr/cdrFile/cdrFile.go
@@ -487,7 +487,8 @@ func (cdfFile *CDRFile) Decoding(fileName string) {
 
 	// fmt.Println("[Decode]cdrfileheader:\n", cdfFile.Hdr)
 
-	tail := n + 2
+	var tail uint32
+	tail = uint32(n) + 2
 
 	for i := 1; i <= int(numberOfCdrsInFile); i++ {
 		cdrLength := binary.BigEndian.Uint16(data[tail : tail+2])
@@ -506,10 +507,10 @@ func (cdfFile *CDRFile) Decoding(fileName string) {
 
 		cdr := CDR{
 			Hdr:     cdrHeader,
-			CdrByte: data[tail+5 : tail+5+cdrLength],
+			CdrByte: data[tail+5 : tail+5+uint32(cdrLength)],
 		}
 		cdfFile.CdrList = append(cdfFile.CdrList, cdr)
-		tail += 5 + cdrLength
+		tail += 5 + uint32(cdrLength)
 	}
 	// fmt.Println("[Decode]cdrfile:\n", cdfFile)
 	// fmt.Printf("%#v\n", cdfFile)

--- a/internal/context/ue_context.go
+++ b/internal/context/ue_context.go
@@ -40,6 +40,7 @@ type ChfUe struct {
 	RatingChan    chan *diam.Message
 	RatingType    map[int32]charging_datatype.RequestSubType
 	RateSessionId uint32
+	Records       []*cdrType.CHFRecord
 
 	// lock
 	Cdr    map[string]*cdrType.CHFRecord
@@ -58,6 +59,7 @@ func (ue *ChfUe) init() {
 	config := factory.ChfConfig
 
 	ue.Cdr = make(map[string]*cdrType.CHFRecord)
+	ue.Records = []*cdrType.CHFRecord{}
 	ue.VolumeLimit = config.Configuration.VolumeLimit
 	ue.VolumeLimitPDU = config.Configuration.VolumeLimitPDU
 	ue.QuotaValidityTime = config.Configuration.QuotaValidityTime

--- a/internal/sbi/processor/cdr.go
+++ b/internal/sbi/processor/cdr.go
@@ -258,6 +258,7 @@ func dumpCdrFile(ueid string, records []*cdrType.CHFRecord) error {
 	cdrfile.Hdr.HeaderLength = uint32(54 + cdrfile.Hdr.LengthOfCdrRouteingFilter + cdrfile.Hdr.LengthOfPrivateExtension)
 	cdrfile.Hdr.NumberOfCdrsInFile = uint32(len(records))
 	cdrfile.Hdr.FileLength = cdrfile.Hdr.HeaderLength
+	logger.ChargingdataPostLog.Traceln("cdrfile.Hdr.NumberOfCdrsInFile:", uint32(len(records)))
 
 	for _, record := range records {
 		cdrBytes, err := asn.BerMarshalWithParams(&record, "explicit,choice")
@@ -274,7 +275,7 @@ func dumpCdrFile(ueid string, records []*cdrType.CHFRecord) error {
 		}
 		cdrfile.CdrList = append(cdrfile.CdrList, tmpCdr)
 
-		cdrfile.Hdr.FileLength += uint32(cdrHdr.CdrLength) + 5
+		cdrfile.Hdr.FileLength += uint32(len(cdrBytes)) + 5
 	}
 
 	cdrfile.Encoding("/tmp/" + ueid + ".cdr")

--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"net/http"
 	"strconv"
@@ -13,6 +14,8 @@ import (
 	"golang.org/x/exp/constraints"
 
 	"github.com/fiorix/go-diameter/diam/datatype"
+	"github.com/free5gc/chf/cdr/asn"
+	"github.com/free5gc/chf/cdr/cdrConvert"
 	"github.com/free5gc/chf/cdr/cdrType"
 	"github.com/free5gc/chf/internal/abmf"
 	"github.com/free5gc/chf/internal/cgf"
@@ -186,6 +189,7 @@ func (p *Processor) ChargingDataCreate(chargingData models.ChargingDataRequest) 
 	}
 
 	ue.Cdr[chargingSessionId] = cdr
+	ue.Records = append(ue.Records, ue.Cdr[chargingSessionId])
 
 	if chargingData.OneTimeEvent {
 		err = p.CloseCDR(cdr, false)
@@ -219,7 +223,6 @@ func (p *Processor) ChargingDataCreate(chargingData models.ChargingDataRequest) 
 func (p *Processor) ChargingDataUpdate(
 	chargingData models.ChargingDataRequest, chargingSessionId string,
 ) (*models.ChargingDataResponse, *models.ProblemDetails) {
-	var records []*cdrType.CHFRecord
 
 	self := chf_context.GetSelf()
 	ueId := chargingData.SubscriberIdentifier
@@ -239,6 +242,34 @@ func (p *Processor) ChargingDataUpdate(
 	responseBody, partialRecord := p.BuildConvergedChargingDataUpdateResopone(chargingData)
 
 	cdr := ue.Cdr[chargingSessionId]
+
+	if len(ue.Records) > 1 {
+		cdr = ue.Records[len(ue.Records)-1]
+	}
+
+	cdrBytes, errBer := asn.BerMarshalWithParams(&cdr, "explicit,choice")
+	if errBer != nil {
+		problemDetails := &models.ProblemDetails{
+			Status: http.StatusBadRequest,
+		}
+		return nil, problemDetails
+	}
+
+	var chgDataBytes []byte
+	if chargingData.MultipleUnitUsage != nil && len(chargingData.MultipleUnitUsage) != 0 {
+		cdrMultiUnitUsage := cdrConvert.MultiUnitUsageToCdr(chargingData.MultipleUnitUsage)
+		chgDataBytes, _ = asn.BerMarshalWithParams(&cdrMultiUnitUsage, "explicit,choice")
+	}
+
+	if len(cdrBytes)+len(chgDataBytes) > math.MaxUint16 {
+		var newRecord *cdrType.CHFRecord
+		cdrJson, _ := json.Marshal(cdr)
+		json.Unmarshal(cdrJson, &newRecord)
+		newRecord.ChargingFunctionRecord.ListOfMultipleUnitUsage = []cdrType.MultipleUnitUsage{}
+		cdr = newRecord
+		ue.Records = append(ue.Records, cdr)
+	}
+
 	err := p.UpdateCDR(cdr, chargingData)
 	if err != nil {
 		problemDetails := &models.ProblemDetails{
@@ -270,10 +301,7 @@ func (p *Processor) ChargingDataUpdate(
 			"CDR Record Sequence Number after Reopen %+v", *cdr.ChargingFunctionRecord.RecordSequenceNumber)
 	}
 
-	for _, cdr := range ue.Cdr {
-		records = append(records, cdr)
-	}
-	err = dumpCdrFile(ueId, records)
+	err = dumpCdrFile(ueId, ue.Records)
 	if err != nil {
 		problemDetails := &models.ProblemDetails{
 			Status: http.StatusBadRequest,


### PR DESCRIPTION
Fix Two Issues in CHF When Processing CDR

1. When the traffic exceeds a certain threshold (around 700KB), the Webconsole displays the error:
`[ERRO][WEBUI][BillingLog] parseCDR error when unmarshal with params: offset > next`,
and the usage data cannot be displayed on the Webconsole.

2. According to TS 32.297 Section 5.2 "File Format Principles," a CDR file contains multiple CDRs. However, in CHF, charging data is updated to only one CDR. This causes the `cdrBytes` length in `internal/sbi/processor`'s `dumpCdrFile()` to grow increasingly larger, eventually exceeding the `uint16` range and resulting in an overflow in `cdrHdr.CdrLength`.