### PR TITLE
fix: wrong http status HandlingdataRelease

### DIFF
--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -124,7 +124,7 @@ func (p *Processor) HandleChargingdataRelease(
 
 	problemDetails := p.ChargingDataRelease(chargingdata, chargingSessionId)
 	if problemDetails == nil {
-		c.Status(http.StatusBadRequest)
+		c.Status(http.StatusNoContent)
 		return
 	}
 	c.JSON(int(problemDetails.Status), problemDetails)


### PR DESCRIPTION
Hello ! 

I noticed that the HandleChargingdataRelease function is returning a wrong http status in case of success. [TS 32 291 p18](https://www.etsi.org/deliver/etsi_ts/132200_132299/132291/17.03.00_60/ts_132291v170300p.pdf)

Thanks,

Samy.

