### PR TITLE
fix: status 204 cannot contain a message body

### DIFF
--- a/internal/sbi/api_convergedcharging.go
+++ b/internal/sbi/api_convergedcharging.go
@@ -185,5 +185,5 @@ func (s *Server) RechargePut(c *gin.Context) {
 
 	s.Processor().NotifyRecharge(ueId, int32(rg))
 
-	c.JSON(http.StatusNoContent, gin.H{})
+	c.Status(http.StatusNoContent)
 }


### PR DESCRIPTION
Based on RFC 7231, a 204 response is terminated by the first empty line after the header fields because it cannot contain a message body.