### PR TITLE
fix(notifier): add OAuth2 token to nchf-callback outbound call to SMF

### DIFF
--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"encoding/json"
 	"math"
 	"net/http"
@@ -64,7 +63,15 @@ func (p *Processor) SendChargingNotification(notifyUri string, notifyRequest mod
 	logger.NotifyEventLog.Warn("Send Charging Notification  to SMF: uri: ", notifyUri)
 	chargingNotifyRequest := Nchf_ConvergedCharging.NewPostChargingNotificationRequest()
 	chargingNotifyRequest.SetChargingNotifyRequest(notifyRequest)
-	_, err := client.DefaultApi.PostChargingNotification(context.Background(), notifyUri, chargingNotifyRequest)
+
+	ctx, pd, err := chf_context.GetSelf().GetTokenCtx(
+		models.ServiceName("nchf-callback"), models.NrfNfManagementNfType_SMF)
+	if err != nil {
+		logger.NotifyEventLog.Warnf("SendChargingNotification get token failed: %+v", pd)
+		return
+	}
+
+	_, err = client.DefaultApi.PostChargingNotification(ctx, notifyUri, chargingNotifyRequest)
 	if err != nil {
 		logger.NotifyEventLog.Warnf("Charging Notification Failed[%s]", err.Error())
 		return

--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -65,7 +65,7 @@ func (p *Processor) SendChargingNotification(notifyUri string, notifyRequest mod
 	chargingNotifyRequest.SetChargingNotifyRequest(notifyRequest)
 
 	ctx, pd, err := chf_context.GetSelf().GetTokenCtx(
-		models.ServiceName("nchf-callback"), models.NrfNfManagementNfType_SMF)
+		models.ServiceName("nsmf-callback"), models.NrfNfManagementNfType_SMF)
 	if err != nil {
 		logger.NotifyEventLog.Warnf("SendChargingNotification get token failed: %+v", pd)
 		return


### PR DESCRIPTION
**Problem**
- `SendChargingNotification` sent `nchf-callback` requests to SMF using `context.Background()`, bypassing OAuth2. SMF with OAuth2 enforcement rejects these with 401.

**Changes**
- `internal/sbi/processor/converged_charging.go`: replace `context.Background()` with `chf_context.GetSelf().GetTokenCtx("nchf-callback", NrfNfManagementNfType_SMF)` in `SendChargingNotification`