### PR TITLE
fix: CHF panics on wrong ChargingDataRef in partial-record reopen

### DIFF
--- a/internal/sbi/processor/cdr.go
+++ b/internal/sbi/processor/cdr.go
@@ -29,8 +29,14 @@ func (p *Processor) OpenCDR(
 	// Record Sequence Number(Conditional IE): Partial record sequence number, only present in case of partial records.
 	// Partial CDR: Fragments of CDR, for long session charging
 	if partialRecord {
-		// TODO partial record
-		cdr := ue.Cdr[sessionId]
+		cdr, ok := ue.Cdr[sessionId]
+		if !ok || cdr == nil {
+			return nil, fmt.Errorf("charging session[%s] not found", sessionId)
+		}
+		if cdr.ChargingFunctionRecord == nil {
+			return nil, fmt.Errorf("charging session[%s] has invalid CDR", sessionId)
+		}
+
 		partialRecordSeqNum := self.RecordSequenceNumber[sessionId]
 		partialRecordSeqNum++
 		cdr.ChargingFunctionRecord.RecordSequenceNumber = &(partialRecordSeqNum)

--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"net/http"
 	"strconv"
@@ -240,14 +241,21 @@ func (p *Processor) ChargingDataUpdate(
 	ue.CULock.Lock()
 	defer ue.CULock.Unlock()
 
+	cdr, ok := ue.Cdr[chargingSessionId]
+	if !ok || cdr == nil {
+		detail := fmt.Sprintf("ChargingDataRef[%s] not found", chargingSessionId)
+		logger.ChargingdataPostLog.Warnln(detail)
+		problemDetails := &models.ProblemDetails{
+			Title:  "Context Not Found",
+			Status: http.StatusNotFound,
+			Detail: detail,
+			Cause:  "CONTEXT_NOT_FOUND",
+		}
+		return nil, problemDetails
+	}
+
 	// Online charging: Rate, Account, Reservation
 	responseBody, partialRecord := p.BuildConvergedChargingDataUpdateResopone(chargingData)
-
-	cdr := ue.Cdr[chargingSessionId]
-
-	if len(ue.Records) > 1 {
-		cdr = ue.Records[len(ue.Records)-1]
-	}
 
 	cdrBytes, errCdrBer := asn.BerMarshalWithParams(&cdr, "explicit,choice")
 	if errCdrBer != nil {
@@ -287,6 +295,7 @@ func (p *Processor) ChargingDataUpdate(
 
 		newRecord.ChargingFunctionRecord.ListOfMultipleUnitUsage = []cdrType.MultipleUnitUsage{}
 		cdr = newRecord
+		ue.Cdr[chargingSessionId] = cdr
 		ue.Records = append(ue.Records, cdr)
 	}
 
@@ -313,10 +322,16 @@ func (p *Processor) ChargingDataUpdate(
 			return nil, problemDetails
 		}
 
-		_, oper_err := p.OpenCDR(chargingData, ue, chargingSessionId, partialRecord)
+		reopenedCdr, oper_err := p.OpenCDR(chargingData, ue, chargingSessionId, partialRecord)
 		if oper_err != nil {
 			logger.ChargingdataPostLog.Error("OpenCDR error:", oper_err)
+			problemDetails := &models.ProblemDetails{
+				Status: http.StatusBadRequest,
+				Detail: oper_err.Error(),
+			}
+			return nil, problemDetails
 		}
+		ue.Cdr[chargingSessionId] = reopenedCdr
 		logger.ChargingdataPostLog.Tracef(
 			"CDR Record Sequence Number after Reopen %+v", *cdr.ChargingFunctionRecord.RecordSequenceNumber)
 	}

--- a/internal/sbi/processor/converged_charging_update_test.go
+++ b/internal/sbi/processor/converged_charging_update_test.go
@@ -1,0 +1,58 @@
+package processor
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/free5gc/chf/cdr/cdrType"
+	chf_context "github.com/free5gc/chf/internal/context"
+	"github.com/free5gc/openapi/models"
+)
+
+func TestChargingDataUpdateRejectsUnknownChargingDataRef(t *testing.T) {
+	self := chf_context.GetSelf()
+	supi := "imsi-208930000000950"
+
+	ue := &chf_context.ChfUe{
+		Supi: supi,
+		Cdr: map[string]*cdrType.CHFRecord{
+			"valid-session": {
+				ChargingFunctionRecord: &cdrType.ChargingRecord{},
+			},
+		},
+		Records: []*cdrType.CHFRecord{
+			{ChargingFunctionRecord: &cdrType.ChargingRecord{}},
+			{ChargingFunctionRecord: &cdrType.ChargingRecord{}},
+		},
+	}
+
+	self.UePool.Store(supi, ue)
+	t.Cleanup(func() {
+		self.UePool.Delete(supi)
+	})
+
+	p := &Processor{}
+	response, problemDetails := p.ChargingDataUpdate(models.ChfConvergedChargingChargingDataRequest{
+		SubscriberIdentifier: supi,
+	}, "does-not-exist-partial")
+
+	require.Nil(t, response)
+	require.NotNil(t, problemDetails)
+	require.Equal(t, http.StatusNotFound, int(problemDetails.Status))
+	require.Equal(t, "CONTEXT_NOT_FOUND", problemDetails.Cause)
+}
+
+func TestOpenCDRPartialRecordReturnsErrorWhenSessionMissing(t *testing.T) {
+	p := &Processor{}
+
+	ue := &chf_context.ChfUe{
+		Supi: "imsi-208930000000951",
+		Cdr:  map[string]*cdrType.CHFRecord{},
+	}
+
+	cdr, err := p.OpenCDR(models.ChfConvergedChargingChargingDataRequest{}, ue, "missing-session", true)
+	require.Nil(t, cdr)
+	require.Error(t, err)
+}


### PR DESCRIPTION
- Fixes a panic when a wrong ChargingDataRef is used in partial-record flows.
- Adds session validation in ChargingDataUpdate: unknown or nil charging-session context returns a controlled 404 ProblemDetails.
- Removes the unsafe fallback to the latest record and keeps ue.Cdr[chargingSessionId] aligned during partial-record rollover.
- Hardens OpenCDR(..., partialRecord=true) with defensive nil/session checks.
- Adds tests.

Fixes: free5gc/free5gc#950