### PR TITLE
fix: CHF panics with nil pointer dereference

### DIFF
--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -168,6 +168,7 @@ func (p *Processor) ChargingDataCreate(
 	}
 
 	ue.CULock.Lock()
+	defer ue.CULock.Unlock()
 	ue.NotifyUri = chargingData.NotifyUri
 
 	consumerId := chargingData.NfConsumerIdentification.NFName
@@ -176,8 +177,6 @@ func (p *Processor) ChargingDataCreate(
 	}
 	cdr, err := p.OpenCDR(chargingData, ue, chargingSessionId, false)
 	if err != nil {
-		// Lock in line 158
-		ue.CULock.Unlock()
 		logger.ChargingdataPostLog.Errorf("OpenCDR failed: %v", err)
 		problemDetails := &models.ProblemDetails{
 			Status: http.StatusBadRequest,
@@ -187,8 +186,6 @@ func (p *Processor) ChargingDataCreate(
 
 	err = p.UpdateCDR(cdr, chargingData)
 	if err != nil {
-		// Lock in line 158
-		ue.CULock.Unlock()
 		problemDetails := &models.ProblemDetails{
 			Status: http.StatusBadRequest,
 		}
@@ -197,7 +194,6 @@ func (p *Processor) ChargingDataCreate(
 
 	ue.Cdr[chargingSessionId] = cdr
 	ue.Records = append(ue.Records, ue.Cdr[chargingSessionId])
-	ue.CULock.Unlock()
 
 	if chargingData.OneTimeEvent {
 		err = p.CloseCDR(cdr, false)


### PR DESCRIPTION
This Issue fixes free5gc/free5gc#1023.

- This update further hardens CULock handling by applying defer unlock immediately after lock acquisition, ensuring the lock is always released even if a panic occurs or the function returns early, and preventing persistent deadlock/DoS for the same SUPI.