### PR TITLE
fix(processor): defer CULock.Unlock in ChargingDataCreate to prevent panic-induced DoS

### DIFF
--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -167,7 +167,13 @@ func (p *Processor) ChargingDataCreate(
 		return nil, "", problemDetails
 	}
 
+	// Hold CULock across the create flow with defer so that any panic
+	// inside OpenCDR/UpdateCDR (e.g. dereferencing a nil sub-field of
+	// the request) cannot leave the lock permanently held and DoS every
+	// subsequent charging request for this SUPI (#1023).
 	ue.CULock.Lock()
+	defer ue.CULock.Unlock()
+
 	ue.NotifyUri = chargingData.NotifyUri
 
 	consumerId := chargingData.NfConsumerIdentification.NFName
@@ -176,8 +182,6 @@ func (p *Processor) ChargingDataCreate(
 	}
 	cdr, err := p.OpenCDR(chargingData, ue, chargingSessionId, false)
 	if err != nil {
-		// Lock in line 158
-		ue.CULock.Unlock()
 		logger.ChargingdataPostLog.Errorf("OpenCDR failed: %v", err)
 		problemDetails := &models.ProblemDetails{
 			Status: http.StatusBadRequest,
@@ -187,8 +191,6 @@ func (p *Processor) ChargingDataCreate(
 
 	err = p.UpdateCDR(cdr, chargingData)
 	if err != nil {
-		// Lock in line 158
-		ue.CULock.Unlock()
 		problemDetails := &models.ProblemDetails{
 			Status: http.StatusBadRequest,
 		}
@@ -197,7 +199,6 @@ func (p *Processor) ChargingDataCreate(
 
 	ue.Cdr[chargingSessionId] = cdr
 	ue.Records = append(ue.Records, ue.Cdr[chargingSessionId])
-	ue.CULock.Unlock()
 
 	if chargingData.OneTimeEvent {
 		err = p.CloseCDR(cdr, false)

--- a/internal/sbi/processor/converged_charging.go
+++ b/internal/sbi/processor/converged_charging.go
@@ -167,10 +167,6 @@ func (p *Processor) ChargingDataCreate(
 		return nil, "", problemDetails
 	}
 
-	// Hold CULock across the create flow with defer so that any panic
-	// inside OpenCDR/UpdateCDR (e.g. dereferencing a nil sub-field of
-	// the request) cannot leave the lock permanently held and DoS every
-	// subsequent charging request for this SUPI (#1023).
 	ue.CULock.Lock()
 	defer ue.CULock.Unlock()
 


### PR DESCRIPTION
## What

Refs free5gc/free5gc#1023.

`ChargingDataCreate` acquires `ue.CULock` manually and only releases it along the explicit error-return paths it knows about. Any panic between `Lock()` and the success `Unlock()` (for example, a nil sub-field of the incoming `ChargingDataRequest` deeper in `OpenCDR` / `UpdateCDR`) leaves the mutex permanently held. Every subsequent charging request for the same SUPI then blocks on that lock - a DoS amplifier on top of the original panic.

The reproducer in free5gc/free5gc#1023 demonstrates this exactly: phase 1 succeeds and creates the UE, phase 2 panics + returns 500, phase 3 confirms every later request for the same SUPI hangs indefinitely.

## Fix

Switch to the same `defer ue.CULock.Unlock()` pattern that `ChargingDataUpdate` and `ChargingDataRelease` already use, and remove the now-redundant manual `Unlock` calls along the explicit error paths. Behaviour on the success and known error paths is unchanged; the only difference is that a runtime panic now releases the mutex during stack unwinding instead of parking it indefinitely.

This does not by itself fix every nil-deref panic that could fire inside the create flow, but it removes the persistence of the DoS - after this change, the affected SUPI recovers as soon as gin's recovery middleware unwinds the stack.

## Verification

Locally on macOS, go 1.26.2:

- `gofmt -s -l`: clean
- `go vet ./internal/sbi/processor/...`: clean
- `go test -race -count=1 ./internal/...`: all existing processor / util / consumer tests pass

Net diff: +6 / -5 in `internal/sbi/processor/converged_charging.go`.

Refs free5gc/free5gc#1023